### PR TITLE
feat(MessageLogger): Remove deleted messages and edits from chat immediately

### DIFF
--- a/MessageLogger/src/main/java/io/github/juby210/acplugins/MessageLogger.java
+++ b/MessageLogger/src/main/java/io/github/juby210/acplugins/MessageLogger.java
@@ -13,6 +13,7 @@ import android.text.Spanned;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.RelativeSizeSpan;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -26,6 +27,7 @@ import com.aliucord.patcher.PreHook;
 import com.aliucord.wrappers.ChannelWrapper;
 import com.discord.databinding.WidgetGuildContextMenuBinding;
 import com.discord.models.deserialization.gson.InboundGatewayGsonParser;
+import com.discord.models.domain.ModelMessageDelete;
 import com.discord.models.message.Message;
 import com.discord.stores.*;
 import com.discord.utilities.color.ColorCompat;
@@ -47,6 +49,8 @@ import com.google.gson.stream.JsonReader;
 
 import java.io.StringReader;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import io.github.juby210.acplugins.messagelogger.*;
 import kotlin.jvm.functions.Function1;
@@ -134,6 +138,11 @@ public final class MessageLogger extends Plugin {
         sqlite.close();
     }
 
+    private CopyOnWriteArrayList<Long> hiddenDeletes = new CopyOnWriteArrayList<>();
+    private CopyOnWriteArrayList<Long> hiddenEdits = new CopyOnWriteArrayList<>();
+    private AtomicBoolean disableDeletePatch = new AtomicBoolean(false);
+    private AtomicBoolean disableUpdatePatch = new AtomicBoolean(false);
+
     private void patchWidgetChatListActions() throws Throwable {
         var hideIcon = Utils.getAppContext().getDrawable(com.lytefast.flexinput.R.e.design_ic_visibility_off).mutate();
 
@@ -158,10 +167,23 @@ public final class MessageLogger extends Plugin {
                         lay.addView(tw, lay.getChildCount());
                         tw.setOnClickListener((v) -> {
                             if (isDeleted) {
+                                hiddenDeletes.addIfAbsent(messageId);
                                 sqlite.removeDeletedMessage(messageId);
+                                disableDeletePatch.set(true);
+                                StoreStream.getMessages().handleMessageDelete(
+                                    new ModelMessageDelete(message.getChannelId(), messageId)
+                                );
                             }
                             if (isEdited) {
+                                hiddenEdits.addIfAbsent(messageId);
                                 sqlite.removeEditedMessage(messageId);
+                                if(!isDeleted) {
+                                    disableUpdatePatch.set(true);
+                                    StoreStream.getMessages().handleMessageUpdate(
+                                        message.synthesizeApiMessage()
+                                    );
+                                    updateMessages(messageId);
+                                }
                             }
                             Utils.showToast("Removed From Logs");
                             ((WidgetChatListActions) cf.thisObject).dismiss();
@@ -273,7 +295,7 @@ public final class MessageLogger extends Plugin {
 
     private void patchDeleteMessages() {
         patcher.patch(StoreMessagesHolder.class, "deleteMessages", new Class<?>[]{ long.class, List.class }, new PreHook(param -> {
-            if (!sqlite.getBoolSetting("logDeletes", true)) {
+            if (!sqlite.getBoolSetting("logDeletes", true) || disableDeletePatch.compareAndSet(true, false)) {
                 return;
             }
             var channelId = (long) param.args[0];
@@ -290,6 +312,7 @@ public final class MessageLogger extends Plugin {
             for (var id : newDeleted) {
                 var msg = getCachedMessage(channelId, id);
                 if (msg == null) continue;
+                hiddenDeletes.remove(id);
                 // User author;
                 // if (!selfDelete && (author = msg.getAuthor()) != null && new CoreUser(author).getId() == StoreStream.getUsers().getMe().getId()) selfDelete = true;
                 var channelDeletes = deletedMessagesRecord.computeIfAbsent(channelId, k -> new ArrayList<>());
@@ -314,6 +337,7 @@ public final class MessageLogger extends Plugin {
 
     private void patchUpdateMessages() {
         patcher.patch(StoreMessagesHolder.class, "updateMessages", new Class<?>[]{ com.discord.api.message.Message.class }, new PreHook(param -> {
+            if(disableUpdatePatch.compareAndSet(true, false)) return;
             var msg = new Message((com.discord.api.message.Message) param.args[0]);
             var id = msg.getId();
             var edited = msg.getEditedTimestamp();
@@ -332,6 +356,7 @@ public final class MessageLogger extends Plugin {
                     ) {
                         String content;
                         if (origMsg != null && (content = origMsg.getContent()) != null && !content.equals(msg.getContent())) {
+                            hiddenEdits.remove(id);
                             var channelEdits = editedMessagesRecord.computeIfAbsent(channelId, k -> new ArrayList<>());
                             channelEdits.add(id);
                             var record = messageRecord.computeIfAbsent(id, k -> new MessageRecord());
@@ -375,6 +400,13 @@ public final class MessageLogger extends Plugin {
             var record = messageRecord.get(id);
             if (record == null) return;
 
+            //prevent removed deleted messages from sometimes re-appearing after app is sent to background
+            if (hiddenDeletes.contains(id)) {
+                View root = ((WidgetChatListAdapterItemMessage) param.thisObject).itemView;
+                root.setVisibility(View.GONE);
+                root.setLayoutParams(new ViewGroup.LayoutParams(0, 0));
+            }
+
             try {
                 var textView = (SimpleDraweeSpanTextView) param.args[0];
                 var builder = (DraweeSpanStringBuilder) mDraweeStringBuilder.get(textView);
@@ -396,7 +428,7 @@ public final class MessageLogger extends Plugin {
                         " (deleted: " + TimeUtils.toReadableTimeString(context, record.deleteData.time, clock) + ")");
                 }
 
-                if (record.editHistory.size() > 0) {
+                if ((record.editHistory.size() > 0) && (!hiddenEdits.contains(id))) {
                     var data = ((WidgetChatListItem) param.thisObject).adapter.getData();
                     if (data != null) {
                         MessagePreprocessor messagePreprocessor = (MessagePreprocessor) getMessagePreprocessor.invoke(

--- a/MessageLogger/src/main/java/io/github/juby210/acplugins/MessageLogger.java
+++ b/MessageLogger/src/main/java/io/github/juby210/acplugins/MessageLogger.java
@@ -13,7 +13,6 @@ import android.text.Spanned;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.RelativeSizeSpan;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -138,7 +137,6 @@ public final class MessageLogger extends Plugin {
         sqlite.close();
     }
 
-    private CopyOnWriteArrayList<Long> hiddenDeletes = new CopyOnWriteArrayList<>();
     private CopyOnWriteArrayList<Long> hiddenEdits = new CopyOnWriteArrayList<>();
     private AtomicBoolean disableDeletePatch = new AtomicBoolean(false);
     private AtomicBoolean disableUpdatePatch = new AtomicBoolean(false);
@@ -167,10 +165,9 @@ public final class MessageLogger extends Plugin {
                         lay.addView(tw, lay.getChildCount());
                         tw.setOnClickListener((v) -> {
                             if (isDeleted) {
-                                hiddenDeletes.addIfAbsent(messageId);
                                 sqlite.removeDeletedMessage(messageId);
                                 disableDeletePatch.set(true);
-                                StoreStream.getMessages().handleMessageDelete(
+                                StoreStream.access$handleMessageDelete(
                                     new ModelMessageDelete(message.getChannelId(), messageId)
                                 );
                             }
@@ -179,7 +176,7 @@ public final class MessageLogger extends Plugin {
                                 sqlite.removeEditedMessage(messageId);
                                 if(!isDeleted) {
                                     disableUpdatePatch.set(true);
-                                    StoreStream.getMessages().handleMessageUpdate(
+                                    StoreStream.access$handleMessageUpdate(
                                         message.synthesizeApiMessage()
                                     );
                                     updateMessages(messageId);
@@ -312,7 +309,6 @@ public final class MessageLogger extends Plugin {
             for (var id : newDeleted) {
                 var msg = getCachedMessage(channelId, id);
                 if (msg == null) continue;
-                hiddenDeletes.remove(id);
                 // User author;
                 // if (!selfDelete && (author = msg.getAuthor()) != null && new CoreUser(author).getId() == StoreStream.getUsers().getMe().getId()) selfDelete = true;
                 var channelDeletes = deletedMessagesRecord.computeIfAbsent(channelId, k -> new ArrayList<>());
@@ -399,13 +395,6 @@ public final class MessageLogger extends Plugin {
             if ((channelDeletes == null || !channelDeletes.contains(id)) && (channelEdits == null || !channelEdits.contains(id))) return;
             var record = messageRecord.get(id);
             if (record == null) return;
-
-            //prevent removed deleted messages from sometimes re-appearing after app is sent to background
-            if (hiddenDeletes.contains(id)) {
-                View root = ((WidgetChatListAdapterItemMessage) param.thisObject).itemView;
-                root.setVisibility(View.GONE);
-                root.setLayoutParams(new ViewGroup.LayoutParams(0, 0));
-            }
 
             try {
                 var textView = (SimpleDraweeSpanTextView) param.args[0];

--- a/MessageLogger/src/main/java/io/github/juby210/acplugins/MessageLogger.java
+++ b/MessageLogger/src/main/java/io/github/juby210/acplugins/MessageLogger.java
@@ -49,7 +49,6 @@ import com.google.gson.stream.JsonReader;
 import java.io.StringReader;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 import io.github.juby210.acplugins.messagelogger.*;
 import kotlin.jvm.functions.Function1;
@@ -137,9 +136,9 @@ public final class MessageLogger extends Plugin {
         sqlite.close();
     }
 
-    private CopyOnWriteArrayList<Long> hiddenEdits = new CopyOnWriteArrayList<>();
     private AtomicBoolean disableDeletePatch = new AtomicBoolean(false);
     private AtomicBoolean disableUpdatePatch = new AtomicBoolean(false);
+    private StoreStream storeStream = StoreStream.Companion.access$getCollector$p(StoreStream.Companion);
 
     private void patchWidgetChatListActions() throws Throwable {
         var hideIcon = Utils.getAppContext().getDrawable(com.lytefast.flexinput.R.e.design_ic_visibility_off).mutate();
@@ -166,17 +165,20 @@ public final class MessageLogger extends Plugin {
                         tw.setOnClickListener((v) -> {
                             if (isDeleted) {
                                 sqlite.removeDeletedMessage(messageId);
+                                removeCached(messageId);
                                 disableDeletePatch.set(true);
                                 StoreStream.access$handleMessageDelete(
+                                    storeStream,
                                     new ModelMessageDelete(message.getChannelId(), messageId)
                                 );
                             }
                             if (isEdited) {
-                                hiddenEdits.addIfAbsent(messageId);
                                 sqlite.removeEditedMessage(messageId);
+                                removeCached(messageId);
                                 if(!isDeleted) {
                                     disableUpdatePatch.set(true);
                                     StoreStream.access$handleMessageUpdate(
+                                        storeStream,
                                         message.synthesizeApiMessage()
                                     );
                                     updateMessages(messageId);
@@ -352,7 +354,6 @@ public final class MessageLogger extends Plugin {
                     ) {
                         String content;
                         if (origMsg != null && (content = origMsg.getContent()) != null && !content.equals(msg.getContent())) {
-                            hiddenEdits.remove(id);
                             var channelEdits = editedMessagesRecord.computeIfAbsent(channelId, k -> new ArrayList<>());
                             channelEdits.add(id);
                             var record = messageRecord.computeIfAbsent(id, k -> new MessageRecord());
@@ -417,7 +418,7 @@ public final class MessageLogger extends Plugin {
                         " (deleted: " + TimeUtils.toReadableTimeString(context, record.deleteData.time, clock) + ")");
                 }
 
-                if ((record.editHistory.size() > 0) && (!hiddenEdits.contains(id))) {
+                if (record.editHistory.size() > 0) {
                     var data = ((WidgetChatListItem) param.thisObject).adapter.getData();
                     if (data != null) {
                         MessagePreprocessor messagePreprocessor = (MessagePreprocessor) getMessagePreprocessor.invoke(
@@ -465,6 +466,13 @@ public final class MessageLogger extends Plugin {
 
     private void updateCached(Long id, Message message) {
         cachedMessages.put(id, message);
+    }
+
+    private void removeCached(Long id) {
+        cachedMessages.remove(id);
+        deletedMessagesRecord.remove(id);
+        editedMessagesRecord.remove(id);
+        messageRecord.remove(id);
     }
 
     // some display utils

--- a/MessageLogger/src/main/java/io/github/juby210/acplugins/messagelogger/SQLite.java
+++ b/MessageLogger/src/main/java/io/github/juby210/acplugins/messagelogger/SQLite.java
@@ -236,10 +236,10 @@ public final class SQLite extends SQLiteOpenHelper {
             Utils.showToast("Cannot import database from '" + exported + "' as it does not exist");
             return;
         }
-        db.beginTransaction();
         try {
             String query = "ATTACH DATABASE ? AS exportdb";
             db.execSQL(query, new Object[]{ exported });
+            db.beginTransaction();
             query = "INSERT INTO " + TABLE_NAME + " SELECT * FROM exportdb." + TABLE_NAME;
             db.execSQL(query);
             query = "INSERT INTO " + TABLE_NAME_EDITS + " SELECT * FROM exportdb." + TABLE_NAME_EDITS;
@@ -330,4 +330,5 @@ public final class SQLite extends SQLiteOpenHelper {
         onCreate(db);
     }
 }
+
 

--- a/MessageLogger/src/main/java/io/github/juby210/acplugins/messagelogger/SQLite.java
+++ b/MessageLogger/src/main/java/io/github/juby210/acplugins/messagelogger/SQLite.java
@@ -269,10 +269,10 @@ public final class SQLite extends SQLiteOpenHelper {
         } catch (IOException e) {
             e.printStackTrace();
         }
-        db.beginTransaction();
         try {
             String query = "ATTACH DATABASE ? AS exportdb";
             db.execSQL(query, new Object[]{ exported });
+            db.beginTransaction();
             db.execSQL("DROP TABLE IF EXISTS exportdb." + TABLE_NAME);
             db.execSQL("DROP TABLE IF EXISTS exportdb." + TABLE_NAME_EDITS);
             db.execSQL("DROP TABLE IF EXISTS exportdb." + TABLE_NAME_GUILDS);
@@ -330,3 +330,4 @@ public final class SQLite extends SQLiteOpenHelper {
         onCreate(db);
     }
 }
+


### PR DESCRIPTION
Having to restart is really annoying and doesn't really make sense.

~~There is still a strange issue where removed deleted messages will re-appear in chat after some time (usually after switching channels and/or sending app to background) even though they have been handled, so I hide their root view.
This doesn't update dividers unfortunately, but still better than nothing.~~ nah I'm just dumb

Requires #77 to build but already includes #75 (it's been half a year bruh)